### PR TITLE
ci: fix CMAKE_ARGS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [
+        os:
+          [
             {
               name: "Ubuntu 22.04",
               family: "linux",
@@ -52,7 +53,7 @@ jobs:
               family: "macos",
               runner: "macos-14",
               arch: "arm64",
-            }
+            },
           ]
     name: Build and Test | ${{ matrix.os.name }} | ${{ matrix.os.arch }}
     runs-on: ${{ matrix.os.runner }}
@@ -67,9 +68,7 @@ jobs:
           cd third_party/opensta
           brew bundle install
           echo "PATH=$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$PATH" >> $GITHUB_ENV
-          echo "CMAKE_ARGS=$CMAKE_ARGS -DTCL_LIBRARY=$(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib" >> $GITHUB_ENV
-          echo "CMAKE_ARGS=$CMAKE_ARGS -DTCL_INCLUDE_PATH=$(brew --prefix tcl-tk@8)/include/tcl-tk" >> $GITHUB_ENV
-          echo "CMAKE_ARGS=$CMAKE_ARGS -DFLEX_INCLUDE_DIR=$(brew --prefix flex)/include" >> $GITHUB_ENV
+          echo "CMAKE_ARGS=-DTCL_LIBRARY=$(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib -DTCL_INCLUDE_PATH=$(brew --prefix tcl-tk@8)/include/tcl-tk -DFLEX_INCLUDE_DIR=$(brew --prefix flex)/include" >> $GITHUB_ENV
       - if: ${{ matrix.os.family == 'linux' }}
         name: Apt Dependencies
         run: |
@@ -106,4 +105,3 @@ jobs:
           make -j$(python3 -c 'import os; print(os.cpu_count(), end="")')
       - run: |
           make test
-


### PR DESCRIPTION
- Fix GitHub Actions syntax for adding brew-related CMAKE_ARGS to the environment.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `CMAKE_ARGS` syntax in GitHub Actions for macOS builds in `.github/workflows/ci.yml`.
> 
>   - **GitHub Actions**:
>     - Fixes syntax for setting `CMAKE_ARGS` in `.github/workflows/ci.yml` for macOS builds.
>     - Consolidates multiple `echo` commands into one to correctly set `CMAKE_ARGS` in the environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fliberty2json&utm_source=github&utm_medium=referral)<sup> for f0aaae439f755305503d7bcbf36eb6598e69fe24. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->