### PR TITLE
misc: reduce ram utilization by not saving parse structure

### DIFF
--- a/src/STALibertyParser.cpp
+++ b/src/STALibertyParser.cpp
@@ -179,9 +179,9 @@ class Visitor: public LibertyGroupVisitor {
 		top[define_ptr]["valtype"] = attrTypeName(define->valueType());
 	}
   // Predicates to save parse structure after visits.
-  bool save(LibertyGroup *group) { return true; }
-  bool save(LibertyAttr *attr) { return true; }
-  bool save(LibertyVariable *variable) { return true; }
+  bool save(LibertyGroup *group) { return false; }
+  bool save(LibertyAttr *attr) { return false; }
+  bool save(LibertyVariable *variable) { return false; }
 };
 
 STALibertyParser::STALibertyParser(std::string filename, bool include_src_attributes): filename_(filename) {


### PR DESCRIPTION
RAM utilization can be further reduced by streaming out JSON data instead of saving it in-memory, but this is low effort, low risk, already saves a lot of memory and is worth merging standalone.



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduce RAM usage in `STALibertyParser.cpp` by not saving parse structure in `Visitor` class.
> 
>   - **Behavior**:
>     - Modify `save()` functions in `Visitor` class in `STALibertyParser.cpp` to return `false`, preventing saving of parse structure.
>   - **Performance**:
>     - Reduces RAM utilization by not storing parse structure in memory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fliberty2json&utm_source=github&utm_medium=referral)<sup> for d5e18d164516f4ce06efffa0f3b5c32e5bdd789f. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->