### PR TITLE
fix: potential segfault + better memory handling

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -84,7 +84,7 @@ make test
 ### Dependencies
 
 ```bash
-nix develop github:librelane/librelane/dev#opensta
+nix develop
 ```
 
 ### Build
@@ -94,9 +94,6 @@ make release ADDITIONAL_CMAKE_OPTIONS="$cmakeFlags"
 ```
 
 ### Test
-
-Python is required for testing and unfortunately not included in the Nix
-environment.
 
 ```bash
 make test

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,125 @@
+{
+  "nodes": {
+    "ciel": {
+      "inputs": {
+        "nix-eda": [
+          "librelane",
+          "nix-eda"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764091696,
+        "narHash": "sha256-AWbkHL0zO3tD0mE3dZIcj8mVND7o3imTxOpEfOtlRDI=",
+        "owner": "fossi-foundation",
+        "repo": "ciel",
+        "rev": "afcb23d368614ffa1e7e96584ed33f839c71c576",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fossi-foundation",
+        "repo": "ciel",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "librelane",
+          "nix-eda",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "librelane": {
+      "inputs": {
+        "ciel": "ciel",
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "nix-eda": "nix-eda"
+      },
+      "locked": {
+        "lastModified": 1772651287,
+        "narHash": "sha256-r+822ch59hsOzTwtt+DGsphxQGr7/j9ZqjjKQySxY4w=",
+        "owner": "librelane",
+        "repo": "librelane",
+        "rev": "d8f806b2c835fdbeb3698e54d15a3390761377dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "librelane",
+        "ref": "dev",
+        "repo": "librelane",
+        "type": "github"
+      }
+    },
+    "nix-eda": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1772639720,
+        "narHash": "sha256-KkfPpENVHu9/WAMJaIzUZCZVV3tzz1shw/shey9cC3M=",
+        "owner": "fossi-foundation",
+        "repo": "nix-eda",
+        "rev": "bd012d6fd62325dfc44528dcfd6d6f82e3a929e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fossi-foundation",
+        "ref": "6.5.0",
+        "repo": "nix-eda",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766201043,
+        "narHash": "sha256-eplAP+rorKKd0gNjV3rA6+0WMzb1X1i16F5m5pASnjA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b3aad468604d3e488d627c0b43984eb60e75e782",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "librelane": "librelane"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs.librelane.url = "github:librelane/librelane/dev";
+
+  outputs = {
+    self,
+    librelane,
+    ...
+  }: let
+    nix-eda = librelane.inputs.nix-eda;
+    nixpkgs = nix-eda.inputs.nixpkgs;
+    lib = nixpkgs.lib;
+  in {
+    legacyPackages = nix-eda.forAllSystems (
+      system:
+        import nix-eda.inputs.nixpkgs {
+          inherit system;
+          overlays = [
+            nix-eda.overlays.default
+            librelane.overlays.default
+          ];
+        }
+    );
+
+    devShells = nix-eda.forAllSystems (
+      system: let
+        pkgs = self.legacyPackages."${system}";
+      in {
+        default = pkgs.opensta.overrideAttrs (attrs': attrs: {
+          nativeBuildInputs = with pkgs; attrs.nativeBuildInputs ++ [python3];
+        });
+      }
+    );
+  };
+}

--- a/include/STALibertyTranslator.hpp
+++ b/include/STALibertyTranslator.hpp
@@ -25,14 +25,15 @@
 #include <string>
 #include <optional>
 #include <filesystem>
+#include <memory>
 
 using string = std::string;
 
-class Visitor;
+struct Visitor;
 
 // C++ wrapper for OpenSTA Liberty parser
 class STALibertyTranslator: public sta::Report {
-		Visitor *visitor_;
+		std::unique_ptr<Visitor> visitor_;
 		std::filesystem::path filename_;
 		std::optional<string> err_ = std::nullopt;
 	public:

--- a/src/STALibertyTranslator.cpp
+++ b/src/STALibertyTranslator.cpp
@@ -31,8 +31,7 @@
 using namespace sta;
 using namespace std::literals::string_literals;
 
-class Visitor: public LibertyGroupVisitor {
-	friend class STALibertyTranslator;
+struct Visitor: public LibertyGroupVisitor {
 	std::filesystem::path src_;
 	jsoncons::json_stream_encoder out_;
 	bool include_src_attributes_;
@@ -56,6 +55,12 @@ class Visitor: public LibertyGroupVisitor {
 	};
 	
 	std::stack<Group> stack_;
+	Group &stack_top() {
+		if (stack_.empty()) {
+			throw std::runtime_error("Group stack unexpectedly empty.");
+		}
+		return stack_.top();
+	}
 	
 	static const char* groupTypeName(LibertyGroupType t) {
 		switch (t) {
@@ -112,11 +117,11 @@ class Visitor: public LibertyGroupVisitor {
 	}
 
 	void end(LibertyGroup *group) {
-		if (stack_.size() && stack_.top().subgroups_) {
+		if (stack_top().subgroups_) {
 			out_.end_array();
 		}
 		
-		auto &attrs = stack_.top().attrs_;
+		auto &attrs = stack_top().attrs_;
 		if (attrs.size()) {
 			for (const auto &[name, value]: attrs.object_range()) {
 				out_.key(name);
@@ -138,13 +143,13 @@ class Visitor: public LibertyGroupVisitor {
 			out_.end_array();
 		}
 		
-		auto &variables = stack_.top().variables_;
+		auto &variables = stack_top().variables_;
 		for (auto &[name, value]: variables) {
 			out_.key(name);
 			out_.double_value(value);
 		}
 		
-		auto &defines = stack_.top().defines_;
+		auto &defines = stack_top().defines_;
 		if (defines.size()) {
 			out_.key("defines");
 			out_.begin_object();
@@ -176,7 +181,7 @@ class Visitor: public LibertyGroupVisitor {
 		const char *allowed_group_name,
 		const char *valtype
 	) {
-		auto &defines = stack_.top().defines_;
+		auto &defines = stack_top().defines_;
 		auto it = defines.find(name);
 		if (it != defines.end() && it->second.allowed_group_name_.length() != 0) {
 			it->second.allowed_group_name_ += "|"s + string(allowed_group_name);
@@ -191,8 +196,17 @@ class Visitor: public LibertyGroupVisitor {
 
 	void visitAttr(LibertyAttr *attr) {
 		if (attr->isComplex()) {
+			auto values_p = attr->values();
 			if (strcmp(attr->name(), "define_group") == 0) {
-				auto &values = *attr->values();
+				if (values_p == nullptr) {
+					std::cerr << "WARNING: Malformed define_group on line " << attr->line() << ": no arguments provided." << std::endl;
+					return;
+				}
+				auto &values = *values_p;
+				if (values.size() < 2) {
+					std::cerr << "WARNING: Malformed define_group on line " << attr->line() << ": less than two arguments provided." << std::endl;
+					return;
+				}
 				
 				const char *valtype = "undefined_valuetype";
 				if (values.size() >= 3) {
@@ -205,34 +219,39 @@ class Visitor: public LibertyGroupVisitor {
 				);
 			} else {
 				jsoncons::json values(jsoncons::json_array_arg);
-				for (auto value: *attr->values()) {
-					if (value->isFloat()) {
-						values.push_back(value->floatValue());
-					} else if (value->isString()) {
-						values.push_back(value->stringValue());
+				if (values_p != nullptr) {
+					for (auto value: *values_p) {
+						if (value->isFloat()) {
+							values.push_back(value->floatValue());
+						} else if (value->isString()) {
+							values.push_back(value->stringValue());
+						}
 					}
+					
 				}
-				stack_.top().attrs_[attr->name()] = values;
+				stack_top().attrs_[attr->name()] = values;
 			}
 		} else {
 			auto value = attr->firstValue();
 			if (value->isFloat()) {
-				stack_.top().attrs_[attr->name()] = value->floatValue();
+				stack_top().attrs_[attr->name()] = value->floatValue();
 			} else if (value->isString()) {
 				if (strcmp(value->stringValue(), "true") == 0) {
-					stack_.top().attrs_[attr->name()] = 1;
+					stack_top().attrs_[attr->name()] = 1;
 				} else if (strcmp(value->stringValue(), "false") == 0) {
-					stack_.top().attrs_[attr->name()] = 0;
+					stack_top().attrs_[attr->name()] = 0;
 				} else {
-					stack_.top().attrs_[attr->name()] = value->stringValue();
+					stack_top().attrs_[attr->name()] = value->stringValue();
 				}
 			} else {
-				throw std::runtime_error(string("Unhandled attribute ") + attr->name());
+				// should be unreachable but just in case a freak bug happens from
+				// updating OpenSTA
+				throw std::runtime_error(string("non-float or string attribute ") + attr->name() + " at line " + std::to_string(attr->line()));
 			}
 		}
 	}
 	void visitVariable(LibertyVariable *variable) {
-		stack_.top().variables_.push_back({
+		stack_top().variables_.push_back({
 				variable->variable(),
 				variable->value()
 		});
@@ -257,9 +276,9 @@ STALibertyTranslator::STALibertyTranslator(
 	std::ostream *out_stream,
 	bool include_src_attributes
 ): filename_(filename) {
-	visitor_ = new Visitor(filename, out_stream, include_src_attributes);
+	visitor_ = std::unique_ptr<Visitor>(new Visitor(filename, out_stream, include_src_attributes));
 	try {
-		parseLibertyFile(filename_.c_str(), visitor_, this);
+		parseLibertyFile(filename_.c_str(), visitor_.get(), this);
 	} catch (sta::Exception &e) {
 		err_ = e.what();
 	}
@@ -267,9 +286,7 @@ STALibertyTranslator::STALibertyTranslator(
 	log_stream_ = fdopen(STDERR_FILENO, "w");
 }
 
-STALibertyTranslator::~STALibertyTranslator() {
-	delete visitor_;
-}
+STALibertyTranslator::~STALibertyTranslator() {}
 
 int STALibertyTranslator::check() {
 	return err_.has_value();

--- a/src/liberty2json.cpp
+++ b/src/liberty2json.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 	program.add_argument("--outfile", "-o").help("name of the output JSON file");
 	program.add_argument("--check").help("check the Liberty file for errors only and exit").flag();
 	program.add_argument("--debug").help("enable debug mode").flag();
-	program.add_argument("--indent").help("enable indentation in file output").flag();
+	program.add_argument("--indent").help("has no effect and is kept for backwards compatibility").flag();
 	program.add_argument("--src").help("include source attribute in top-level groups").flag();
 
 	try {
@@ -51,44 +51,39 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	// Parse Liberty file
-	try {
-		sta::initSta();
-		sta::Sta *sta = new sta::Sta();
-		sta::Sta::setSta(sta);
-		sta->makeComponents();
-		
-		std::ostream *out_stream = nullptr;
-		MAKE_SCOPE_EXIT(scope_exit) {
-			delete out_stream;
-		};
-		if (program.is_used("--outfile")) {
-			out_stream = new std::ofstream(program.get<string>("--outfile"));
-		} else if (program.get<bool>("--check")) {
+// Parse Liberty file
+	sta::initSta();
+	sta::Sta *sta = new sta::Sta();
+	sta::Sta::setSta(sta);
+	sta->makeComponents();
+	
+	std::ostream *out_stream = nullptr;
+	MAKE_SCOPE_EXIT(scope_exit) {
+		delete out_stream;
+	};
+	if (program.is_used("--outfile")) {
+		out_stream = new std::ofstream(program.get<string>("--outfile"));
+	} else if (program.get<bool>("--check")) {
 #if defined(_WIN32)
-			out_stream = new std::ofstream("NUL");
+		out_stream = new std::ofstream("NUL");
 #else
-			// Assume UNIX
-			out_stream = new std::ofstream("/dev/null");
+		// Assume UNIX
+		out_stream = new std::ofstream("/dev/null");
 #endif
-		} else {
-			out_stream = &std::cout;
-			scope_exit.dismiss();
-		}
-		
-		auto parser = std::make_shared<STALibertyTranslator>(
-			program.get<string>("filename"),
-			out_stream,
-			program.get<bool>("--src")
-		);
-		
-		if (parser->check()) {
-			std::cerr << "ERROR: " << parser->get_error_text() << std::endl;
-			return 1;
-		}
-		return 0;
-	} catch (std::exception &e) {
-		std::cerr << "FATAL: " << e.what() << std::endl;
+	} else {
+		out_stream = &std::cout;
+		scope_exit.dismiss();
+	}
+	
+	auto parser = std::make_shared<STALibertyTranslator>(
+		program.get<string>("filename"),
+		out_stream,
+		program.get<bool>("--src")
+	);
+	
+	if (parser->check()) {
+		std::cerr << "ERROR: " << parser->get_error_text() << std::endl;
 		return 1;
 	}
+	return 0;
 }

--- a/test/test_segfault.lib
+++ b/test/test_segfault.lib
@@ -1,0 +1,5 @@
+library(segfault_tests) {
+  define_group();
+  define_group(one_arg);
+  really_complex_attribute();
+}

--- a/test/test_segfault.py
+++ b/test/test_segfault.py
@@ -1,0 +1,23 @@
+import json
+import subprocess
+
+import pytest
+
+
+def test_segfault():
+    p = subprocess.run(
+        [str(pytest.l2j), str(pytest.test_root / "test_segfault.lib")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf8",
+    )
+    assert p.returncode == 0, "segfault test did not exit cleanly"
+    assert (
+        "Malformed define_group on line 2: no arguments provided" in p.stderr
+    ), "define_group with no arguments did not emit a warning"
+    assert (
+        "Malformed define_group on line 3: less than two arguments provided" in p.stderr
+    ), "define_group with one argument did not emit a warning"
+    assert json.loads(p.stdout) == {
+        "library": {"really_complex_attribute": [], "names": ["segfault_tests"]}
+    }, "unexpected stdout"


### PR DESCRIPTION
- fix segfault when define_group() or a complex attribute have no arguments
- always bounds-check group stack before access, throwing an exception if empty
- use unique_ptr for Visitor to automatically deallocate
- remove pointless "FATAL" try/catch in main function so backwards may print the stack trace properly in case of failures
- add nix flake with python so testing isn't awkward