### PR TITLE
Update Verilog goldens for Liberty pg_pin ports

### DIFF
--- a/test/buspindir.ref.v
+++ b/test/buspindir.ref.v
@@ -5,11 +5,17 @@
 (* area = "1.0" *)
 (* memory =  1  *)
 (* blackbox =  1  *)
-module myram(CLK, DI, DO);
+module myram(CLK, DI, DO, VDD, VSS);
   input CLK;
   wire CLK;
   input [49:0] DI;
   wire [49:0] DI;
   output [49:0] DO;
   wire [49:0] DO;
+  (* pg_type = "primary_power" *)
+  input VDD;
+  wire VDD;
+  (* pg_type = "primary_ground" *)
+  input VSS;
+  wire VSS;
 endmodule

--- a/test/example.icg.ref.v
+++ b/test/example.icg.ref.v
@@ -4,7 +4,7 @@
 (* LeakagePower = "0" *)
 (* area = "0.26244" *)
 (* blackbox =  1  *)
-module ICGx1_ASAP7_75t_L(GCLK, CLK, ENA, SE);
+module ICGx1_ASAP7_75t_L(GCLK, CLK, ENA, SE, VDD, VSS);
   output GCLK;
   wire GCLK;
   input CLK;
@@ -13,4 +13,10 @@ module ICGx1_ASAP7_75t_L(GCLK, CLK, ENA, SE);
   wire ENA;
   input SE;
   wire SE;
+  (* pg_type = "primary_power" *)
+  input VDD;
+  wire VDD;
+  (* pg_type = "primary_ground" *)
+  input VSS;
+  wire VSS;
 endmodule

--- a/test/newstuff.ref.v
+++ b/test/newstuff.ref.v
@@ -15,16 +15,20 @@ endmodule
 (* LeakagePower = "0" *)
 (* area = "0" *)
 (* blackbox =  1  *)
-module cell2(pin1);
+module cell2(pin1, pin2);
   input pin1;
   wire pin1;
+  input pin2;
+  wire pin2;
 endmodule
 
 (* leakage_power_unit = "1pW" *)
 (* LeakagePower = "0" *)
 (* area = "0" *)
 (* blackbox =  1  *)
-module cell3(pin1);
+module cell3(pin1, pin2);
   input pin1;
   wire pin1;
+  input pin2;
+  wire pin2;
 endmodule


### PR DESCRIPTION
## Summary

`test/*.ref.v` are compared byte-for-byte by Preqorsor's `test_liberty2module`
against what the `read_liberty2json` Yosys frontend emits for each `.lib` here.
That frontend now declares every `pg_pin` group as a port
(Silimate/yosys#267), because RTL that instantiates a macro connects its
supplies by name and previously had nothing to bind against. The three
libraries in this repo that carry `pg_pin` groups therefore gain supply port
declarations in their goldens.

- `buspindir` and `example.icg` gain `VDD` / `VSS` with their `pg_type`.
- `newstuff` is the odd one: its `pg_pin(pin2)` declares no `pg_type`, so
  `pin2` appears as a plain port with no attribute marking it a supply. Yosys
  erases a string attribute set to the empty string, so there is nothing to
  record. Real vendor libraries always specify `pg_type`; the spec requires it.

Nothing in this repo's own tests reads these files, so CI here is unaffected.

## Test plan

- [x] `pytest tests/unit/eda/test_liberty.py` in Preqorsor passes against these
      goldens with a pyosys built from Silimate/yosys#267, and fails against a
      pyosys without it (which is the intended coupling).
- [x] `make release` builds this repo clean.

Made with [Cursor](https://cursor.com)